### PR TITLE
noFallDamage: fix wrong clientside hp

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -477,7 +477,8 @@ void Client::step(float dtime)
 		if (envEvent.type == CEE_PLAYER_DAMAGE) {
 			u16 damage = envEvent.player_damage.amount;
 
-			if (envEvent.player_damage.send_to_server && ! g_settings->getBool("prevent_natural_damage"))
+                        //if (envEvent.player_damage.send_to_server && ! g_settings->getBool("prevent_natural_damage"))
+			if (envEvent.player_damage.send_to_server)
 				sendDamage(damage);
 
 			// Add to ClientEvent queue

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -287,7 +287,7 @@ void ClientEnvironment::step(float dtime)
 		if (speed > tolerance && !player_immortal) {
 			f32 damage_f = (speed - tolerance) / BS * post_factor;
 			u16 damage = (u16)MYMIN(damage_f + 0.5, U16_MAX);
-			if (damage != 0) {
+			if (!g_settings->getBool("prevent_natural_damage") != 0) {
 				damageLocalPlayer(damage, true);
 				m_client->getEventManager()->put(
 					new SimpleTriggerEvent(MtEvent::PLAYER_FALLING_DAMAGE));


### PR DESCRIPTION
This fixes damage on fall being reported clientside

Write a csm in df that does localplayer:get_hp() and see the hp stay at 0 when falling from something high.

This completely prevents the effects from fall damage.