### PR TITLE
New cheats for DragonFireClient

### DIFF
--- a/builtin/client/cheats/init.lua
+++ b/builtin/client/cheats/init.lua
@@ -24,6 +24,7 @@ core.cheats = {
 		["NoSlip"] = "noslip",
 		["SpeedHack"] = "speedhack",
 		["AutoSprint"] = "autosprint",
+		["AlwaysJump"] = "alwaysjump",
 	},
 	["Render"] = {
 		["Xray"] = "xray",

--- a/builtin/client/cheats/init.lua
+++ b/builtin/client/cheats/init.lua
@@ -39,6 +39,7 @@ core.cheats = {
 		["NodeESP"] = "enable_node_esp",
 		["CheatHUD"] = "cheat_hud",
 		["PlayerESP"] = "enable_player_esp",
+		["PlayerTracers"] = "enable_player_tracers",
 	},
 	["World"] = {
 		["FastDig"] = "fastdig",

--- a/builtin/client/cheats/init.lua
+++ b/builtin/client/cheats/init.lua
@@ -21,7 +21,7 @@ core.cheats = {
 		["HighJump"] = "highjump",
 		["LessGravity"] = "lessgravity",
 		["JetPack"] = "jetpack",
-		["AntiSlip"] = "antislip",
+		["NoSlip"] = "noslip",
 		["SpeedHack"] = "speedhack",
 		["AutoSprint"] = "autosprint",
 	},

--- a/builtin/client/cheats/init.lua
+++ b/builtin/client/cheats/init.lua
@@ -19,6 +19,8 @@ core.cheats = {
 		["NoSlow"] = "no_slow",
 		["AutoSneak"] = "autosneak",
 		["HighJump"] = "highjump",
+		["LessGravity"] = "lessgravity",
+		["JetPack"] = "jetpack",
 	},
 	["Render"] = {
 		["Xray"] = "xray",

--- a/builtin/client/cheats/init.lua
+++ b/builtin/client/cheats/init.lua
@@ -60,6 +60,7 @@ core.cheats = {
 		["PointLiquids"] = "point_liquids",
 		["PrivBypass"] = "priv_bypass",
 		["AutoRespawn"] = "autorespawn",
+		["LessFallDamage"] = "less_fall_damage",
 	},
 	["Chat"] = {
 		["IgnoreStatus"] = "ignore_status_messages",

--- a/builtin/client/cheats/init.lua
+++ b/builtin/client/cheats/init.lua
@@ -38,8 +38,8 @@ core.cheats = {
 		["NodeTracers"] = "enable_node_tracers",
 		["NodeESP"] = "enable_node_esp",
 		["CheatHUD"] = "cheat_hud",
-		["PlayerESP"] = "enable_player_esp",
-		["PlayerTracers"] = "enable_player_tracers",
+		["EntityESP"] = "enable_entity_esp",
+		["EntityTracers"] = "enable_entity_tracers",
 	},
 	["World"] = {
 		["FastDig"] = "fastdig",

--- a/builtin/client/cheats/init.lua
+++ b/builtin/client/cheats/init.lua
@@ -38,6 +38,7 @@ core.cheats = {
 		["NodeTracers"] = "enable_node_tracers",
 		["NodeESP"] = "enable_node_esp",
 		["CheatHUD"] = "cheat_hud",
+		["PlayerESP"] = "enable_player_esp",
 	},
 	["World"] = {
 		["FastDig"] = "fastdig",

--- a/builtin/client/cheats/init.lua
+++ b/builtin/client/cheats/init.lua
@@ -21,6 +21,9 @@ core.cheats = {
 		["HighJump"] = "highjump",
 		["LessGravity"] = "lessgravity",
 		["JetPack"] = "jetpack",
+		["AntiSlip"] = "antislip",
+		["SpeedHack"] = "speedhack",
+		["AutoSprint"] = "autosprint",
 	},
 	["Render"] = {
 		["Xray"] = "xray",

--- a/builtin/client/cheats/init.lua
+++ b/builtin/client/cheats/init.lua
@@ -17,6 +17,7 @@ core.cheats = {
 		["Jesus"] = "jesus",
 		["NoSlow"] = "no_slow",
 		["AutoSneak"] = "autosneak",
+		["HighJump"] = "highjump",
 	},
 	["Render"] = {
 		["Xray"] = "xray",

--- a/builtin/client/cheats/init.lua
+++ b/builtin/client/cheats/init.lua
@@ -8,6 +8,7 @@ core.cheats = {
 		["CrystalPvP"] = "crystal_pvp",
 		["AutoTotem"] = "autototem",
 		["ThroughWalls"] = "dont_point_nodes",
+		["AutoPunch"] = "autopunch",
 	},
 	["Movement"] = {
 		["Freecam"] = "freecam",

--- a/builtin/client/cheats/movement.lua
+++ b/builtin/client/cheats/movement.lua
@@ -12,3 +12,16 @@ core.register_globalstep(function()
 	end
 end)
  
+-- autosprint
+
+local autosprint_was_enabled = false
+
+core.register_globalstep(function()
+	if core.settings:get_bool("autosprint") then
+		core.set_keypress("special1", true)
+		autosprint_was_enabled = true
+	elseif autosprint_was_enabled then
+		autosprint_was_enabled = false
+		core.set_keypress("special1", false)
+	end
+end)

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -2351,3 +2351,19 @@ enable_node_esp (NodeESP) bool false
 enable_node_tracers (NodeTracers) bool false
 
 node_esp_nodes (NodeESP Nodes) string
+
+highjump (HighJump) bool false
+
+lessgravity (LessGravity) bool false
+
+less_fall_damage (LessFallDamage) bool false
+
+autopunch (AutoPunch) bool false
+
+antislip (AntiSlip) bool false
+
+speedhack (SpeedHack) bool false
+
+jetpack (JetPack) bool false
+
+autosprint (AutoSprint) bool false

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -2360,7 +2360,7 @@ less_fall_damage (LessFallDamage) bool false
 
 autopunch (AutoPunch) bool false
 
-antislip (AntiSlip) bool false
+noslip (NoSlip) bool false
 
 speedhack (SpeedHack) bool false
 

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -37,6 +37,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <algorithm>
 #include "client/renderingengine.h"
 
+/* 
+	A Cheat function (LessGravity)
+*/
+
+float getGravityHack()
+{ return g_settings->getBool("lessgravity") ? 0.5 : 1.0; }
+
+
 /*
 	CAOShaderConstantSetter
 */
@@ -225,7 +233,7 @@ void ClientEnvironment::step(float dtime)
 				v3f speed = lplayer->getSpeed();
 				if (!lplayer->in_liquid)
 					speed.Y -= lplayer->movement_gravity *
-						lplayer->physics_override_gravity * dtime_part * 2.0f;
+						lplayer->physics_override_gravity * dtime_part * 2.0f * getGravityHack();
 
 				// Liquid floating / sinking
 				if (lplayer->in_liquid && !lplayer->swimming_vertical &&

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -296,9 +296,17 @@ void ClientEnvironment::step(float dtime)
 			f32 damage_f = (speed - tolerance) / BS * post_factor;
 			u16 damage = (u16)MYMIN(damage_f + 0.5, U16_MAX);
 			if (damage != 0) {
-				damageLocalPlayer(damage, true);
-				m_client->getEventManager()->put(
-					new SimpleTriggerEvent(MtEvent::PLAYER_FALLING_DAMAGE));
+				if (g_settings->getBool("less_fall_damage")) {
+					damageLocalPlayer(1, true);
+					m_client->getEventManager()->put(
+						new SimpleTriggerEvent(MtEvent::PLAYER_FALLING_DAMAGE));
+				}
+				else
+				{
+					damageLocalPlayer(damage, true);
+					m_client->getEventManager()->put(
+						new SimpleTriggerEvent(MtEvent::PLAYER_FALLING_DAMAGE));
+				}
 			}
 		}
 	}

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3200,7 +3200,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	}
 #endif
 	RenderingEngine::draw_scene(skycolor, m_game_ui->m_flags.show_hud,
-			m_game_ui->m_flags.show_minimap, draw_wield_tool, draw_crosshair, g_settings->getBool("enable_esp"), g_settings->getBool("enable_tracers"), g_settings->getBool("enable_node_esp"), g_settings->getBool("enable_node_tracers"));
+			m_game_ui->m_flags.show_minimap, draw_wield_tool, draw_crosshair, g_settings->getBool("enable_esp"), g_settings->getBool("enable_tracers"), g_settings->getBool("enable_node_esp"), g_settings->getBool("enable_node_tracers"), g_settings->getBool("enable_player_esp"));
 
 	/*
 		Profiler graph

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2401,7 +2401,7 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud, bool show_debug)
 		runData.ldown_for_dig = false;
 	}
 
-	runData.left_punch = false;
+	runData.left_punch = g_settings->getBool("autopunch");
 
 	soundmaker->m_player_leftpunch_sound.name = "";
 
@@ -2811,7 +2811,7 @@ void Game::handlePointingAtObject(const PointedThing &pointed,
 
 	m_game_ui->setInfoText(infotext);
 
-	if (input->getLeftState()) {
+	if (input->getLeftState() || g_settings->getBool("autopunch")) {
 		bool do_punch = false;
 		bool do_punch_damage = false;
 
@@ -2821,7 +2821,7 @@ void Game::handlePointingAtObject(const PointedThing &pointed,
 			runData.object_hit_delay_timer = object_hit_delay;
 		}
 
-		if (input->getLeftClicked())
+		if (input->getLeftClicked() || g_settings->getBool("autopunch"))
 			do_punch = true;
 
 		if (do_punch) {

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3200,7 +3200,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	}
 #endif
 	RenderingEngine::draw_scene(skycolor, m_game_ui->m_flags.show_hud,
-			m_game_ui->m_flags.show_minimap, draw_wield_tool, draw_crosshair, g_settings->getBool("enable_esp"), g_settings->getBool("enable_tracers"), g_settings->getBool("enable_node_esp"), g_settings->getBool("enable_node_tracers"), g_settings->getBool("enable_player_esp"), g_settings->getBool("enable_player_tracers"));
+			m_game_ui->m_flags.show_minimap, draw_wield_tool, draw_crosshair, g_settings->getBool("enable_esp"), g_settings->getBool("enable_tracers"), g_settings->getBool("enable_node_esp"), g_settings->getBool("enable_node_tracers"), g_settings->getBool("enable_entity_esp"), g_settings->getBool("enable_entity_tracers"));
 
 	/*
 		Profiler graph

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3200,7 +3200,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	}
 #endif
 	RenderingEngine::draw_scene(skycolor, m_game_ui->m_flags.show_hud,
-			m_game_ui->m_flags.show_minimap, draw_wield_tool, draw_crosshair, g_settings->getBool("enable_esp"), g_settings->getBool("enable_tracers"), g_settings->getBool("enable_node_esp"), g_settings->getBool("enable_node_tracers"), g_settings->getBool("enable_player_esp"));
+			m_game_ui->m_flags.show_minimap, draw_wield_tool, draw_crosshair, g_settings->getBool("enable_esp"), g_settings->getBool("enable_tracers"), g_settings->getBool("enable_node_esp"), g_settings->getBool("enable_node_tracers"), g_settings->getBool("enable_player_esp"), g_settings->getBool("enable_player_tracers"));
 
 	/*
 		Profiler graph

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -611,7 +611,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 				else
 					speedV.Y = movement_speed_walk;
 			}
-		} else if (m_can_jump) {
+		} else if (m_can_jump || g_settings->getBool("jetpack")) {
 			/*
 				NOTE: The d value in move() affects jump height by
 				raising the height at which the jump speed is kept

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -619,7 +619,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 			*/
 			v3f speedJ = getSpeed();
 			if (speedJ.Y >= -0.5f * BS) {
-				speedJ.Y = movement_speed_jump * physics_override_jump;
+				g_settings->getBool("highjump") ? speedJ.Y = movement_speed_jump * physics_override_jump * 1.5 : speedJ.Y = movement_speed_jump * physics_override_jump;
 				setSpeed(speedJ);
 				m_client->getEventManager()->put(new SimpleTriggerEvent(MtEvent::PLAYER_JUMP));
 			}

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -618,7 +618,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 				at its starting value
 			*/
 			v3f speedJ = getSpeed();
-			if (speedJ.Y >= -0.5f * BS) {
+			if (speedJ.Y >= -0.5f * BS || g_settings->getBool("jetpack")) {
 				g_settings->getBool("highjump") ? speedJ.Y = movement_speed_jump * physics_override_jump * 1.5 : speedJ.Y = movement_speed_jump * physics_override_jump;
 				setSpeed(speedJ);
 				m_client->getEventManager()->put(new SimpleTriggerEvent(MtEvent::PLAYER_JUMP));

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -598,7 +598,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 			m_autojump = false;
 	}
 
-	if (control.jump) {
+	if (control.jump || g_settings->getBool("alwaysjump")) {
 		if (free_move) {
 			if (player_settings.aux1_descends || always_fly_fast) {
 				if (fast_move)

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -1106,7 +1106,7 @@ float LocalPlayer::getSlipFactor(Environment *env, const v3f &speedH)
 	const ContentFeatures &f = nodemgr->get(map->getNode(getStandingNodePos()));
 	int slippery = 0;
 	if (f.walkable)
-		g_settings->getBool("antislip") ? slippery = 0 : slippery = itemgroup_get(f.groups, "slippery");
+		g_settings->getBool("noslip") ? slippery = 0 : slippery = itemgroup_get(f.groups, "slippery");
 
 	if (slippery >= 1) {
 		if (speedH == v3f(0.0f))

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -676,7 +676,10 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 	}
 
 	// Accelerate to target speed with maximum increment
-	accelerate((speedH + speedV) * physics_override_speed,
+	
+	float speedhack_extra_speed = g_settings->getBool("speedhack") ? 2.0 : 1.0;
+	
+	accelerate((speedH + speedV) * physics_override_speed * speedhack_extra_speed,
 		incH * physics_override_speed * slip_factor, incV * physics_override_speed,
 		pitch_move);
 }

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -1106,7 +1106,7 @@ float LocalPlayer::getSlipFactor(Environment *env, const v3f &speedH)
 	const ContentFeatures &f = nodemgr->get(map->getNode(getStandingNodePos()));
 	int slippery = 0;
 	if (f.walkable)
-		slippery = itemgroup_get(f.groups, "slippery");
+		g_settings->getBool("antislip") ? slippery = 0 : slippery = itemgroup_get(f.groups, "slippery");
 
 	if (slippery >= 1) {
 		if (speedH == v3f(0.0f))

--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -57,7 +57,7 @@ void RenderingCore::updateScreenSize()
 }
 
 void RenderingCore::draw(video::SColor _skycolor, bool _show_hud, bool _show_minimap,
-		bool _draw_wield_tool, bool _draw_crosshair, bool _draw_esp, bool _draw_tracers, bool _draw_node_esp, bool _draw_node_tracers, bool _draw_player_esp)
+		bool _draw_wield_tool, bool _draw_crosshair, bool _draw_esp, bool _draw_tracers, bool _draw_node_esp, bool _draw_node_tracers, bool _draw_player_esp, bool _draw_player_tracers)
 {
 	v2u32 ss = driver->getScreenSize();
 	if (screensize != ss) {

--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -109,6 +109,8 @@ void RenderingCore::drawTracersAndESP()
 			aabb3f box;
 			if (! obj->getSelectionBox(&box))
 				continue;
+			if (obj->isPlayer())
+				continue;
 			v3f pos = obj->getPosition() - camera_offset;
 			box.MinEdge += pos;
 			box.MaxEdge += pos;

--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -57,7 +57,7 @@ void RenderingCore::updateScreenSize()
 }
 
 void RenderingCore::draw(video::SColor _skycolor, bool _show_hud, bool _show_minimap,
-		bool _draw_wield_tool, bool _draw_crosshair, bool _draw_esp, bool _draw_tracers, bool _draw_node_esp, bool _draw_node_tracers, bool _draw_player_esp, bool _draw_player_tracers)
+		bool _draw_wield_tool, bool _draw_crosshair, bool _draw_esp, bool _draw_tracers, bool _draw_node_esp, bool _draw_node_tracers, bool _draw_entity_esp, bool _draw_entity_tracers)
 {
 	v2u32 ss = driver->getScreenSize();
 	if (screensize != ss) {
@@ -73,8 +73,8 @@ void RenderingCore::draw(video::SColor _skycolor, bool _show_hud, bool _show_min
 	draw_tracers = _draw_tracers;
 	draw_node_esp = _draw_node_esp;
 	draw_node_tracers = _draw_node_tracers;
-	draw_player_esp = _draw_player_esp;
-	draw_player_tracers = _draw_player_tracers;
+	draw_entity_esp = _draw_entity_esp;
+	draw_entity_tracers = _draw_entity_tracers;
 		
 	beforeDraw();
 	drawAll();
@@ -110,7 +110,7 @@ void RenderingCore::drawTracersAndESP()
 			aabb3f box;
 			if (! obj->getSelectionBox(&box))
 				continue;
-			if (obj->isPlayer())
+			if (! obj->isPlayer())
 				continue;
 			v3f pos = obj->getPosition() - camera_offset;
 			box.MinEdge += pos;
@@ -153,7 +153,7 @@ void RenderingCore::drawTracersAndESP()
 
 	}
 	
- 	if (draw_player_esp || draw_player_tracers) {
+ 	if (draw_entity_esp || draw_entity_tracers) {
 		auto allObjects = env.getAllActiveObjects();
 
 		for (auto &it : allObjects) {
@@ -166,16 +166,16 @@ void RenderingCore::drawTracersAndESP()
 			aabb3f box;
 			if (! obj->getSelectionBox(&box))
 				continue;
-			if (! obj->isPlayer())
+			if (obj->isPlayer())
 				continue;
 			
 			v3f pos = obj->getPosition() - camera_offset;
 			box.MinEdge += pos;
 			box.MaxEdge += pos;
 			if (draw_player_esp)
-				driver->draw3DBox(box, video::SColor(0xFF9900));
+				driver->draw3DBox(box, video::SColor(0x008000));
 			if (draw_player_tracers)
-				driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(0xCC00CC));
+				driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(0xFF0000));
 		}
 	}
 	

--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -172,9 +172,9 @@ void RenderingCore::drawTracersAndESP()
 			v3f pos = obj->getPosition() - camera_offset;
 			box.MinEdge += pos;
 			box.MaxEdge += pos;
-			if (draw_player_esp)
+			if (draw_entity_esp)
 				driver->draw3DBox(box, video::SColor(0x008000));
-			if (draw_player_tracers)
+			if (draw_entity_tracers)
 				driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(0xFF0000));
 		}
 	}

--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -115,9 +115,9 @@ void RenderingCore::drawTracersAndESP()
 			box.MinEdge += pos;
 			box.MaxEdge += pos;
 			if (draw_esp)
-				driver->draw3DBox(box, video::SColor(0x00FF00));
+				driver->draw3DBox(box, video::SColor(255, 255, 255, 255));
 			if (draw_tracers)
-				driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(0xFF0000));
+				driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(255, 255, 255, 255));
 		}
 	}
 	if (draw_node_esp || draw_node_tracers) {

--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -166,7 +166,7 @@ void RenderingCore::drawTracersAndESP()
 			if (! obj->getSelectionBox(&box))
 				continue;
 			if (! obj->isPlayer())
-				continue
+				continue;
 			
 			v3f pos = obj->getPosition() - camera_offset;
 			box.MinEdge += pos;

--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -150,7 +150,7 @@ void RenderingCore::drawTracersAndESP()
 
 	}
 	
- 	if (draw_player_esp) {
+ 	if (draw_player_esp || draw_player_tracers) {
 		auto allObjects = env.getAllActiveObjects();
 
 		for (auto &it : allObjects) {
@@ -169,7 +169,10 @@ void RenderingCore::drawTracersAndESP()
 			v3f pos = obj->getPosition() - camera_offset;
 			box.MinEdge += pos;
 			box.MaxEdge += pos;
-			driver->draw3DBox(box, video::SColor(0xFF9900));
+			if (draw_player_esp)
+				driver->draw3DBox(box, video::SColor(0xFF9900));
+			if (draw_player_tracers)
+				driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(0xCC00CC));
 		}
 	}
 	

--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -74,6 +74,7 @@ void RenderingCore::draw(video::SColor _skycolor, bool _show_hud, bool _show_min
 	draw_node_esp = _draw_node_esp;
 	draw_node_tracers = _draw_node_tracers;
 	draw_player_esp = _draw_player_esp;
+	draw_player_tracers = _draw_player_tracers;
 		
 	beforeDraw();
 	drawAll();

--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -57,7 +57,7 @@ void RenderingCore::updateScreenSize()
 }
 
 void RenderingCore::draw(video::SColor _skycolor, bool _show_hud, bool _show_minimap,
-		bool _draw_wield_tool, bool _draw_crosshair, bool _draw_esp, bool _draw_tracers, bool _draw_node_esp, bool _draw_node_tracers)
+		bool _draw_wield_tool, bool _draw_crosshair, bool _draw_esp, bool _draw_tracers, bool _draw_node_esp, bool _draw_node_tracers, bool _draw_player_esp)
 {
 	v2u32 ss = driver->getScreenSize();
 	if (screensize != ss) {
@@ -73,6 +73,7 @@ void RenderingCore::draw(video::SColor _skycolor, bool _show_hud, bool _show_min
 	draw_tracers = _draw_tracers;
 	draw_node_esp = _draw_node_esp;
 	draw_node_tracers = _draw_node_tracers;
+	draw_player_esp = _draw_player_esp;
 		
 	beforeDraw();
 	drawAll();
@@ -147,6 +148,29 @@ void RenderingCore::drawTracersAndESP()
 			}
 		}
 
+	}
+	
+ 	if (draw_player_esp) {
+		auto allObjects = env.getAllActiveObjects();
+
+		for (auto &it : allObjects) {
+			ClientActiveObject *cao = it.second;
+			if (cao->isLocalPlayer() || cao->getParent())
+				continue;
+			GenericCAO *obj = dynamic_cast<GenericCAO *>(cao);
+			if (! obj)
+				continue;
+			aabb3f box;
+			if (! obj->getSelectionBox(&box))
+				continue;
+			if (! obj->isPlayer())
+				continue
+			
+			v3f pos = obj->getPosition() - camera_offset;
+			box.MinEdge += pos;
+			box.MaxEdge += pos;
+			driver->draw3DBox(box, video::SColor(0xFF9900));
+		}
 	}
 	
 	driver->setMaterial(oldmaterial);

--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -113,9 +113,9 @@ void RenderingCore::drawTracersAndESP()
 			box.MinEdge += pos;
 			box.MaxEdge += pos;
 			if (draw_esp)
-				driver->draw3DBox(box, video::SColor(255, 255, 255, 255));
+				driver->draw3DBox(box, video::SColor(0x00FF00));
 			if (draw_tracers)
-				driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(255, 255, 255, 255));
+				driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(0xFF0000));
 		}
 	}
 	if (draw_node_esp || draw_node_tracers) {

--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -173,9 +173,9 @@ void RenderingCore::drawTracersAndESP()
 			box.MinEdge += pos;
 			box.MaxEdge += pos;
 			if (draw_entity_esp)
-				driver->draw3DBox(box, video::SColor(0x008000));
+				driver->draw3DBox(box, video::SColor(0xFF0000));
 			if (draw_entity_tracers)
-				driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(0xFF0000));
+				driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(0x008000));
 		}
 	}
 	

--- a/src/client/render/core.h
+++ b/src/client/render/core.h
@@ -41,6 +41,7 @@ protected:
 	bool draw_node_esp;
 	bool draw_node_tracers;
 	bool draw_player_esp;
+	bool draw_player_tracers;
 
 	IrrlichtDevice *device;
 	video::IVideoDriver *driver;
@@ -77,7 +78,7 @@ public:
 	void draw(video::SColor _skycolor, bool _show_hud, bool _show_minimap,
 			bool _draw_wield_tool, bool _draw_crosshair, bool _draw_esp,
 			bool _draw_tracers, bool _draw_node_esp, bool _draw_node_tracers,
-		 	bool _draw_player_esp);
+		 	bool _draw_player_esp, bool _draw_player_tracers);
 
 	inline v2u32 getVirtualSize() const { return virtual_size; }
 };

--- a/src/client/render/core.h
+++ b/src/client/render/core.h
@@ -40,6 +40,7 @@ protected:
 	bool draw_tracers;
 	bool draw_node_esp;
 	bool draw_node_tracers;
+	bool draw_player_esp;
 
 	IrrlichtDevice *device;
 	video::IVideoDriver *driver;
@@ -75,7 +76,8 @@ public:
 	void initialize();
 	void draw(video::SColor _skycolor, bool _show_hud, bool _show_minimap,
 			bool _draw_wield_tool, bool _draw_crosshair, bool _draw_esp,
-			bool _draw_tracers, bool _draw_node_esp, bool _draw_node_tracers);
+			bool _draw_tracers, bool _draw_node_esp, bool _draw_node_tracers,
+		 	bool _draw_player_esp);
 
 	inline v2u32 getVirtualSize() const { return virtual_size; }
 };

--- a/src/client/render/core.h
+++ b/src/client/render/core.h
@@ -40,8 +40,8 @@ protected:
 	bool draw_tracers;
 	bool draw_node_esp;
 	bool draw_node_tracers;
-	bool draw_player_esp;
-	bool draw_player_tracers;
+	bool draw_entity_esp;
+	bool draw_entity_tracers;
 
 	IrrlichtDevice *device;
 	video::IVideoDriver *driver;
@@ -78,7 +78,7 @@ public:
 	void draw(video::SColor _skycolor, bool _show_hud, bool _show_minimap,
 			bool _draw_wield_tool, bool _draw_crosshair, bool _draw_esp,
 			bool _draw_tracers, bool _draw_node_esp, bool _draw_node_tracers,
-		 	bool _draw_player_esp, bool _draw_player_tracers);
+		 	bool _draw_entity_esp, bool _draw_entity_tracers);
 
 	inline v2u32 getVirtualSize() const { return virtual_size; }
 };

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -604,9 +604,9 @@ void RenderingEngine::_finalize()
 }
 
 void RenderingEngine::_draw_scene(video::SColor skycolor, bool show_hud,
-		bool show_minimap, bool draw_wield_tool, bool draw_crosshair, bool draw_esp, bool draw_tracers, bool draw_node_esp, bool draw_node_tracers, bool draw_player_esp, bool draw_player_tracers)
+		bool show_minimap, bool draw_wield_tool, bool draw_crosshair, bool draw_esp, bool draw_tracers, bool draw_node_esp, bool draw_node_tracers, bool draw_entity_esp, bool draw_entity_tracers)
 {
-	core->draw(skycolor, show_hud, show_minimap, draw_wield_tool, draw_crosshair, draw_esp, draw_tracers, draw_node_esp, draw_node_tracers, draw_player_esp, draw_player_tracers);
+	core->draw(skycolor, show_hud, show_minimap, draw_wield_tool, draw_crosshair, draw_esp, draw_tracers, draw_node_esp, draw_node_tracers, draw_entity_esp, draw_entity_tracers);
 }
 
 const char *RenderingEngine::getVideoDriverName(irr::video::E_DRIVER_TYPE type)

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -604,9 +604,9 @@ void RenderingEngine::_finalize()
 }
 
 void RenderingEngine::_draw_scene(video::SColor skycolor, bool show_hud,
-		bool show_minimap, bool draw_wield_tool, bool draw_crosshair, bool draw_esp, bool draw_tracers, bool draw_node_esp, bool draw_node_tracers, bool draw_player_esp)
+		bool show_minimap, bool draw_wield_tool, bool draw_crosshair, bool draw_esp, bool draw_tracers, bool draw_node_esp, bool draw_node_tracers, bool draw_player_esp, bool draw_player_tracers)
 {
-	core->draw(skycolor, show_hud, show_minimap, draw_wield_tool, draw_crosshair, draw_esp, draw_tracers, draw_node_esp, draw_node_tracers, draw_player_esp);
+	core->draw(skycolor, show_hud, show_minimap, draw_wield_tool, draw_crosshair, draw_esp, draw_tracers, draw_node_esp, draw_node_tracers, draw_player_esp, draw_player_tracers);
 }
 
 const char *RenderingEngine::getVideoDriverName(irr::video::E_DRIVER_TYPE type)

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -604,9 +604,9 @@ void RenderingEngine::_finalize()
 }
 
 void RenderingEngine::_draw_scene(video::SColor skycolor, bool show_hud,
-		bool show_minimap, bool draw_wield_tool, bool draw_crosshair, bool draw_esp, bool draw_tracers, bool draw_node_esp, bool draw_node_tracers)
+		bool show_minimap, bool draw_wield_tool, bool draw_crosshair, bool draw_esp, bool draw_tracers, bool draw_node_esp, bool draw_node_tracers, bool draw_player_esp)
 {
-	core->draw(skycolor, show_hud, show_minimap, draw_wield_tool, draw_crosshair, draw_esp, draw_tracers, draw_node_esp, draw_node_tracers);
+	core->draw(skycolor, show_hud, show_minimap, draw_wield_tool, draw_crosshair, draw_esp, draw_tracers, draw_node_esp, draw_node_tracers, draw_player_esp);
 }
 
 const char *RenderingEngine::getVideoDriverName(irr::video::E_DRIVER_TYPE type)

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -148,7 +148,7 @@ private:
 			bool clouds = true);
 
 	void _draw_scene(video::SColor skycolor, bool show_hud, bool show_minimap,
-			bool draw_wield_tool, bool draw_crosshair, bool draw_esp, bool draw_tracers, bool draw_node_esp, bool draw_node_tracers);
+			bool draw_wield_tool, bool draw_crosshair, bool draw_esp, bool draw_tracers, bool draw_node_esp, bool draw_node_tracers, bool draw_player_esp, bool draw_player_tracers);
 
 	void _initialize(Client *client, Hud *hud);
 

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -117,10 +117,10 @@ public:
 	}
 
 	inline static void draw_scene(video::SColor skycolor, bool show_hud,
-			bool show_minimap, bool draw_wield_tool, bool draw_crosshair, bool draw_esp, bool draw_tracers, bool draw_node_esp, bool draw_node_tracers)
+			bool show_minimap, bool draw_wield_tool, bool draw_crosshair, bool draw_esp, bool draw_tracers, bool draw_node_esp, bool draw_node_tracers, bool draw_player_esp)
 	{
 		s_singleton->_draw_scene(skycolor, show_hud, show_minimap,
-				draw_wield_tool, draw_crosshair, draw_esp, draw_tracers, draw_node_esp, draw_node_tracers);
+				draw_wield_tool, draw_crosshair, draw_esp, draw_tracers, draw_node_esp, draw_node_tracers, draw_player_esp);
 	}
 
 	inline static void initialize(Client *client, Hud *hud)

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -117,10 +117,10 @@ public:
 	}
 
 	inline static void draw_scene(video::SColor skycolor, bool show_hud,
-			bool show_minimap, bool draw_wield_tool, bool draw_crosshair, bool draw_esp, bool draw_tracers, bool draw_node_esp, bool draw_node_tracers, bool draw_player_esp)
+			bool show_minimap, bool draw_wield_tool, bool draw_crosshair, bool draw_esp, bool draw_tracers, bool draw_node_esp, bool draw_node_tracers, bool draw_player_esp, bool draw_player_tracers)
 	{
 		s_singleton->_draw_scene(skycolor, show_hud, show_minimap,
-				draw_wield_tool, draw_crosshair, draw_esp, draw_tracers, draw_node_esp, draw_node_tracers, draw_player_esp);
+				draw_wield_tool, draw_crosshair, draw_esp, draw_tracers, draw_node_esp, draw_node_tracers, draw_player_esp, draw_player_tracers);
 	}
 
 	inline static void initialize(Client *client, Hud *hud)

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -117,10 +117,10 @@ public:
 	}
 
 	inline static void draw_scene(video::SColor skycolor, bool show_hud,
-			bool show_minimap, bool draw_wield_tool, bool draw_crosshair, bool draw_esp, bool draw_tracers, bool draw_node_esp, bool draw_node_tracers, bool draw_player_esp, bool draw_player_tracers)
+			bool show_minimap, bool draw_wield_tool, bool draw_crosshair, bool draw_esp, bool draw_tracers, bool draw_node_esp, bool draw_node_tracers, bool draw_entity_esp, bool draw_entity_tracers)
 	{
 		s_singleton->_draw_scene(skycolor, show_hud, show_minimap,
-				draw_wield_tool, draw_crosshair, draw_esp, draw_tracers, draw_node_esp, draw_node_tracers, draw_player_esp, draw_player_tracers);
+				draw_wield_tool, draw_crosshair, draw_esp, draw_tracers, draw_node_esp, draw_node_tracers, draw_entity_esp, draw_entity_tracers);
 	}
 
 	inline static void initialize(Client *client, Hud *hud)
@@ -148,8 +148,7 @@ private:
 			bool clouds = true);
 
 	void _draw_scene(video::SColor skycolor, bool show_hud, bool show_minimap,
-			bool draw_wield_tool, bool draw_crosshair, bool draw_esp, bool draw_tracers, bool draw_node_esp, bool draw_node_tracers, bool draw_player_esp, bool draw_player_tracers);
-
+			bool draw_wield_tool, bool draw_crosshair, bool draw_esp, bool draw_tracers, bool draw_node_esp, bool draw_node_tracers, bool draw_entity_esp, bool draw_entity_tracers);
 	void _initialize(Client *client, Hud *hud);
 
 	void _finalize();

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -144,6 +144,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("noslip", "false");
 	settings->setDefault("alwaysjump", "false");
 	settings->setDefault("enable_player_esp", "false");
+	settings->setDefault("enable_player_tracers", "false");
 
 	// Keymap
 	settings->setDefault("remote_port", "30000");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -138,6 +138,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("autopunch", "false");
 	settings->setDefault("lessgravity", "false");
 	settings->setDefault("jetpack", "false");
+	settings->setDefault("less_fall_damage", "false");
 
 	// Keymap
 	settings->setDefault("remote_port", "30000");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -141,7 +141,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("less_fall_damage", "false");
 	settings->setDefault("autosprint", "false");
 	settings->setDefault("speedhack", "false");
-	settings->setDefault("antislip", "false");
+	settings->setDefault("noslip", "false");
 
 	// Keymap
 	settings->setDefault("remote_port", "30000");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -139,6 +139,9 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("lessgravity", "false");
 	settings->setDefault("jetpack", "false");
 	settings->setDefault("less_fall_damage", "false");
+	settings->setDefault("autosprint", "false");
+	settings->setDefault("speedhack", "false");
+	settings->setDefault("antislip", "false");
 
 	// Keymap
 	settings->setDefault("remote_port", "30000");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -136,6 +136,8 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("node_esp_nodes", "");
 	settings->setDefault("highjump", "false");
 	settings->setDefault("autopunch", "false");
+	settings->setDefault("lessgravity", "false");
+	settings->setDefault("jetpack", "false");
 
 	// Keymap
 	settings->setDefault("remote_port", "30000");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -143,8 +143,8 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("speedhack", "false");
 	settings->setDefault("noslip", "false");
 	settings->setDefault("alwaysjump", "false");
-	settings->setDefault("enable_player_esp", "false");
-	settings->setDefault("enable_player_tracers", "false");
+	settings->setDefault("enable_entity_esp", "false");
+	settings->setDefault("enable_entity_tracers", "false");
 
 	// Keymap
 	settings->setDefault("remote_port", "30000");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -142,6 +142,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("autosprint", "false");
 	settings->setDefault("speedhack", "false");
 	settings->setDefault("noslip", "false");
+	settings->setDefault("alwaysjump", "false");
 
 	// Keymap
 	settings->setDefault("remote_port", "30000");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -134,6 +134,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("enable_node_esp", "false");
 	settings->setDefault("enable_node_tracers", "false");
 	settings->setDefault("node_esp_nodes", "");
+	settings->setDefault("highjump", "false");
 
 	// Keymap
 	settings->setDefault("remote_port", "30000");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -143,6 +143,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("speedhack", "false");
 	settings->setDefault("noslip", "false");
 	settings->setDefault("alwaysjump", "false");
+	settings->setDefault("enable_player_esp", "false");
 
 	// Keymap
 	settings->setDefault("remote_port", "30000");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -135,6 +135,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("enable_node_tracers", "false");
 	settings->setDefault("node_esp_nodes", "");
 	settings->setDefault("highjump", "false");
+	settings->setDefault("autopunch", "false");
 
 	// Keymap
 	settings->setDefault("remote_port", "30000");


### PR DESCRIPTION
## This is a fork of _dragonfireclient_ to add more cheats

### Added cheats:

1) JetPack                                               [_Fly into the air when holding jump key_]
2) LessFallDamage                               [_No matter from how high you fall your fall damage is **always** reduced to 0.5 heart_]
3) AutoPunch                                         [_Punch automatically_]
4) HighJump                                          [_Jump 1 block higher then normal_]
5) LessGravity                                       [_Lowers your gravity_]
6) SpeedHack                                       [_Multiplies default movement speed with a factor of 2.0 (Can be **buggy**)_]
7) AutoSprint                                         [_Automatically press the sprint button (Can be usefull in mineclone)_]
8) NoSlip                                               [_Prevents slipping on for example ice_]
9) PlayerESP                                        [_Highlights players_]
10) PlayerTracers                                [_Draw tracers to players_]