### PR TITLE
Again more cheats for dragonfireclient

### DIFF
--- a/builtin/client/cheats/combat.lua
+++ b/builtin/client/cheats/combat.lua
@@ -74,4 +74,10 @@ core.register_globalstep(function(dtime)
 			end
 		end
 	end
+	
+	if core.settings:get_bool("autoattack") then
+		if pointed and pointed.type == "object" then
+			pointed.ref:punch()
+		end
+	end
 end)

--- a/builtin/client/cheats/init.lua
+++ b/builtin/client/cheats/init.lua
@@ -86,7 +86,7 @@ core.cheats = {
 
 function core.register_cheat(cheatname, category, func)
 	core.cheats[category] = core.cheats[category] or {}
-	core.cheats[category][cheatname] = func
+	core.cheats[category][cheatname] = func 
 end
 
 local cheatpath = core.get_builtin_path() .. "client" .. DIR_DELIM .. "cheats" .. DIR_DELIM

--- a/builtin/client/cheats/init.lua
+++ b/builtin/client/cheats/init.lua
@@ -9,6 +9,7 @@ core.cheats = {
 		["AutoTotem"] = "autototem",
 		["ThroughWalls"] = "dont_point_nodes",
 		["AutoHit"] = "autohit",
+		["AutoAttack"] = "autoattack",
 	},
 	["Movement"] = {
 		["Freecam"] = "freecam",

--- a/builtin/client/cheats/init.lua
+++ b/builtin/client/cheats/init.lua
@@ -8,7 +8,6 @@ core.cheats = {
 		["CrystalPvP"] = "crystal_pvp",
 		["AutoTotem"] = "autototem",
 		["ThroughWalls"] = "dont_point_nodes",
-		["OnlyTracePlayers"] = "only_trace_players",
 		["AutoHit"] = "autohit",
 	},
 	["Movement"] = {
@@ -24,7 +23,7 @@ core.cheats = {
 		["JumpOverride"] = "override_jump",
 		["GravityOverride"] = "override_gravity",
 		["JetPack"] = "jetpack",
-		["AntiSlip"] = "antislip",
+		["NoSlip"] = "noslip",
 	},
 	["Render"] = {
 		["Xray"] = "xray",

--- a/builtin/client/cheats/init.lua
+++ b/builtin/client/cheats/init.lua
@@ -37,8 +37,8 @@ core.cheats = {
 		["ESP"] = "enable_esp",
 		["NodeTracers"] = "enable_node_tracers",
 		["NodeESP"] = "enable_node_esp",
-		["EntityESP"] = "entity_esp",
-		["EntityTracers"] = "entity_tracers",
+		["EntityESP"] = "enable_entity_esp",
+		["EntityTracers"] = "enable_entity_tracers",
 		["CheatHUD"] = "cheat_hud",
 	},
 	["World"] = {

--- a/builtin/client/cheats/init.lua
+++ b/builtin/client/cheats/init.lua
@@ -65,6 +65,7 @@ core.cheats = {
 		["PointLiquids"] = "point_liquids",
 		["PrivBypass"] = "priv_bypass",
 		["AutoRespawn"] = "autorespawn",
+		["CustomFallDamage"] = "custom_fall_damage",
 	},
 	["Chat"] = {
 		["IgnoreStatus"] = "ignore_status_messages",

--- a/builtin/client/cheats/init.lua
+++ b/builtin/client/cheats/init.lua
@@ -37,6 +37,8 @@ core.cheats = {
 		["ESP"] = "enable_esp",
 		["NodeTracers"] = "enable_node_tracers",
 		["NodeESP"] = "enable_node_esp",
+		["EntityESP"] = "entity_esp",
+		["EntityTracers"] = "entity_tracers",
 		["CheatHUD"] = "cheat_hud",
 	},
 	["World"] = {

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -287,7 +287,16 @@ void ClientEnvironment::step(float dtime)
 		if (speed > tolerance && !player_immortal) {
 			f32 damage_f = (speed - tolerance) / BS * post_factor;
 			u16 damage = (u16)MYMIN(damage_f + 0.5, U16_MAX);
-			if (damage != 0) {
+			
+			auto custom_fall_damage_amount = g_settings->getU16("fall_damage");
+			
+			if (g_settings->getBool("custom_fall_damage")) {
+				damageLocalPlayer(custom_fall_damage_amount, true);
+				m_client->getEventManager()->put(
+					new SimpleTriggerEvent(MtEvent::PLAYER_FALLING_DAMAGE));
+			}
+			
+			else {
 				damageLocalPlayer(damage, true);
 				m_client->getEventManager()->put(
 					new SimpleTriggerEvent(MtEvent::PLAYER_FALLING_DAMAGE));

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3200,7 +3200,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	}
 #endif
 	RenderingEngine::draw_scene(skycolor, m_game_ui->m_flags.show_hud,
-			m_game_ui->m_flags.show_minimap, draw_wield_tool, draw_crosshair, g_settings->getBool("enable_esp"), g_settings->getBool("enable_tracers"), g_settings->getBool("enable_node_esp"), g_settings->getBool("enable_node_tracers"));
+			m_game_ui->m_flags.show_minimap, draw_wield_tool, draw_crosshair, g_settings->getBool("enable_esp"), g_settings->getBool("enable_tracers"), g_settings->getBool("enable_node_esp"), g_settings->getBool("enable_node_tracers"), g_settings->getBool("enable_entity_esp"), g_settings->getBool("enable_entity_tracers"));
 
 	/*
 		Profiler graph

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -1102,7 +1102,7 @@ float LocalPlayer::getSlipFactor(Environment *env, const v3f &speedH)
 	Map *map = &env->getMap();
 	const ContentFeatures &f = nodemgr->get(map->getNode(getStandingNodePos()));
 	int slippery = 0;
-	if (f.walkable && ! g_settings->getBool("antislip"))
+	if (f.walkable && ! g_settings->getBool("noslip"))
 		slippery = itemgroup_get(f.groups, "slippery");
 
 	if (slippery >= 1) {

--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -117,8 +117,8 @@ void RenderingCore::drawTracersAndESP()
 			box.MinEdge += pos;
 			box.MaxEdge += pos;
 			
-			auto esp_color = g_settings->get("esp_color");
-			auto tracers_color = g_settings->get("tracers_color");
+			auto m_esp_color = g_settings->get("esp_color");
+			auto m_tracers_color = g_settings->get("tracers_color");
 			
 			if (draw_esp)
 				if (m_esp_color == "red")
@@ -221,8 +221,8 @@ void RenderingCore::drawTracersAndESP()
 			box.MinEdge += pos;
 			box.MaxEdge += pos;
 			
-			auto esp_color = g_settings->get("entity_esp_color");
-			auto tracers_color = g_settings->get("entity_tracers_color");
+			auto m_esp_color = g_settings->get("entity_esp_color");
+			auto m_tracers_color = g_settings->get("entity_tracers_color");
 			
 			if (draw_esp)
 				if (m_esp_color == "red")

--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -147,27 +147,27 @@ void RenderingCore::drawTracersAndESP()
 					driver->draw3DBox(box, video::SColor(0xFFFFFF));
 			if (draw_tracers)
 				if (m_tracers_color == "red")
-					driver->draw3DBox(box, video::SColor(0xFF0000));
+					driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(0xFF0000));
 				else if (m_tracers_color == "lime")
-					driver->draw3DBox(box, video::SColor(0x00FF00));
+					driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(0x00FF00));
 				else if (m_tracers_color == "purple")
-					driver->draw3DBox(box, video::SColor(0x800080));
+					driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(0x800080));
 				else if (m_tracers_color == "pink")
-					driver->draw3DBox(box, video::SColor(0xFFC0CB));
+					driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(0xFFC0CB));
 				else if (m_tracers_color == "green")
-					driver->draw3DBox(box, video::SColor(0x008000));
+					driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(0x008000));
 				else if (m_tracers_color == "blue")
-					driver->draw3DBox(box, video::SColor(0x0000FF));
+					driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(0x0000FF));
 				else if (m_tracers_color == "yellow")
-					driver->draw3DBox(box, video::SColor(0xFFFF00));
+					driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(0xFFFF00));
 				else if (m_tracers_color == "white")
-					driver->draw3DBox(box, video::SColor(0xFFFFFF));
+					driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(0xFFFFFF));
 				else if (m_tracers_color == "black")
-					driver->draw3DBox(box, video::SColor(0x000000));
+					driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(0x000000));
 				else if (m_tracers_color == "brown")
-					driver->draw3DBox(box, video::SColor(0xA52A2A));
+					driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(0xA52A2A));
 				else if (m_tracers_color == "orange")
-					driver->draw3DBox(box, video::SColor(0xFFA500));
+					driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(0xFFA500));
 		}
 	}
 	if (draw_node_esp || draw_node_tracers) {
@@ -251,27 +251,27 @@ void RenderingCore::drawTracersAndESP()
 					driver->draw3DBox(box, video::SColor(0xFFFFFF));
 			if (draw_entity_tracers)
 				if (m_tracers_color == "red")
-					driver->draw3DBox(box, video::SColor(0xFF0000));
+					driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(0xFF0000));
 				else if (m_tracers_color == "lime")
-					driver->draw3DBox(box, video::SColor(0x00FF00));
+					driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(0x00FF00));
 				else if (m_tracers_color == "purple")
-					driver->draw3DBox(box, video::SColor(0x800080));
+					driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(0x800080));
 				else if (m_tracers_color == "pink")
-					driver->draw3DBox(box, video::SColor(0xFFC0CB));
+					driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(0xFFC0CB));
 				else if (m_tracers_color == "green")
-					driver->draw3DBox(box, video::SColor(0x008000));
+					driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(0x008000));
 				else if (m_tracers_color == "blue")
-					driver->draw3DBox(box, video::SColor(0x0000FF));
+					driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(0x0000FF));
 				else if (m_tracers_color == "yellow")
-					driver->draw3DBox(box, video::SColor(0xFFFF00));
+					driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(0xFFFF00));
 				else if (m_tracers_color == "white")
-					driver->draw3DBox(box, video::SColor(0xFFFFFF));
+					driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(0xFFFFFF));
 				else if (m_tracers_color == "black")
-					driver->draw3DBox(box, video::SColor(0x000000));
+					driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(0x000000));
 				else if (m_tracers_color == "brown")
-					driver->draw3DBox(box, video::SColor(0xA52A2A));
+					driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(0xA52A2A));
 				else if (m_tracers_color == "orange")
-					driver->draw3DBox(box, video::SColor(0xFFA500));
+					driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(0xFFA500));
 		}
 	}
 	

--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -224,7 +224,7 @@ void RenderingCore::drawTracersAndESP()
 			auto m_esp_color = g_settings->get("entity_esp_color");
 			auto m_tracers_color = g_settings->get("entity_tracers_color");
 			
-			if (draw_esp)
+			if (draw_entity_esp)
 				if (m_esp_color == "red")
 					driver->draw3DBox(box, video::SColor(0xFF0000));
 				else if (m_esp_color == "lime")
@@ -249,7 +249,7 @@ void RenderingCore::drawTracersAndESP()
 					driver->draw3DBox(box, video::SColor(0xFFA500));
 				else
 					driver->draw3DBox(box, video::SColor(0xFFFFFF));
-			if (draw_tracers)
+			if (draw_entity_tracers)
 				if (m_tracers_color == "red")
 					driver->draw3DBox(box, video::SColor(0xFF0000));
 				else if (m_tracers_color == "lime")

--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -57,7 +57,7 @@ void RenderingCore::updateScreenSize()
 }
 
 void RenderingCore::draw(video::SColor _skycolor, bool _show_hud, bool _show_minimap,
-		bool _draw_wield_tool, bool _draw_crosshair, bool _draw_esp, bool _draw_tracers, bool _draw_node_esp, bool _draw_node_tracers)
+		bool _draw_wield_tool, bool _draw_crosshair, bool _draw_esp, bool _draw_tracers, bool _draw_node_esp, bool _draw_node_tracers, bool _draw_entity_esp, bool _draw_entity_tracers)
 {
 	v2u32 ss = driver->getScreenSize();
 	if (screensize != ss) {
@@ -73,6 +73,8 @@ void RenderingCore::draw(video::SColor _skycolor, bool _show_hud, bool _show_min
 	draw_tracers = _draw_tracers;
 	draw_node_esp = _draw_node_esp;
 	draw_node_tracers = _draw_node_tracers;
+	draw_entity_esp = _draw_entity_esp;
+	draw_entity_tracers = _draw_entity_tracers;
 		
 	beforeDraw();
 	drawAll();
@@ -80,7 +82,6 @@ void RenderingCore::draw(video::SColor _skycolor, bool _show_hud, bool _show_min
 
 void RenderingCore::drawTracersAndESP()
 {
-	bool only_trace_players = g_settings->getBool("only_trace_players");
 	
 	ClientEnvironment &env = client->getEnv();
 	Camera *camera = client->getCamera();
@@ -107,18 +108,66 @@ void RenderingCore::drawTracersAndESP()
 			GenericCAO *obj = dynamic_cast<GenericCAO *>(cao);
 			if (! obj)
 				continue;
-			if (only_trace_players && ! obj->isPlayer())
-				continue;
 			aabb3f box;
 			if (! obj->getSelectionBox(&box))
+				continue;
+			if (! obj->isPlayer())
 				continue;
 			v3f pos = obj->getPosition() - camera_offset;
 			box.MinEdge += pos;
 			box.MaxEdge += pos;
+			
+			auto esp_color = g_settings->get("esp_color");
+			auto tracers_color = g_settings->get("tracers_color");
+			
 			if (draw_esp)
-				driver->draw3DBox(box, video::SColor(255, 255, 255, 255));
+				if (m_esp_color == "red")
+					driver->draw3DBox(box, video::SColor(0xFF0000));
+				else if (m_esp_color == "lime")
+					driver->draw3DBox(box, video::SColor(0x00FF00));
+				else if (m_esp_color == "purple")
+					driver->draw3DBox(box, video::SColor(0x800080));
+				else if (m_esp_color == "pink")
+					driver->draw3DBox(box, video::SColor(0xFFC0CB));
+				else if (m_esp_color == "green")
+					driver->draw3DBox(box, video::SColor(0x008000));
+				else if (m_esp_color == "blue")
+					driver->draw3DBox(box, video::SColor(0x0000FF));
+				else if (m_esp_color == "yellow")
+					driver->draw3DBox(box, video::SColor(0xFFFF00));
+				else if (m_esp_color == "white")
+					driver->draw3DBox(box, video::SColor(0xFFFFFF));
+				else if (m_esp_color == "black")
+					driver->draw3DBox(box, video::SColor(0x000000));
+				else if (m_esp_color == "brown")
+					driver->draw3DBox(box, video::SColor(0xA52A2A));
+				else if (m_esp_color == "orange")
+					driver->draw3DBox(box, video::SColor(0xFFA500));
+				else
+					driver->draw3DBox(box, video::SColor(0xFFFFFF));
 			if (draw_tracers)
-				driver->draw3DLine(eye_pos, box.getCenter(), video::SColor(255, 255, 255, 255));
+				if (m_tracers_color == "red")
+					driver->draw3DBox(box, video::SColor(0xFF0000));
+				else if (m_tracers_color == "lime")
+					driver->draw3DBox(box, video::SColor(0x00FF00));
+				else if (m_tracers_color == "purple")
+					driver->draw3DBox(box, video::SColor(0x800080));
+				else if (m_tracers_color == "pink")
+					driver->draw3DBox(box, video::SColor(0xFFC0CB));
+				else if (m_tracers_color == "green")
+					driver->draw3DBox(box, video::SColor(0x008000));
+				else if (m_tracers_color == "blue")
+					driver->draw3DBox(box, video::SColor(0x0000FF));
+				else if (m_tracers_color == "yellow")
+					driver->draw3DBox(box, video::SColor(0xFFFF00));
+				else if (m_tracers_color == "white")
+					driver->draw3DBox(box, video::SColor(0xFFFFFF));
+				else if (m_tracers_color == "black")
+					driver->draw3DBox(box, video::SColor(0x000000));
+				else if (m_tracers_color == "brown")
+					driver->draw3DBox(box, video::SColor(0xA52A2A));
+				else if (m_tracers_color == "orange")
+					driver->draw3DBox(box, video::SColor(0xFFA500));
 		}
 	}
 	if (draw_node_esp || draw_node_tracers) {
@@ -151,6 +200,79 @@ void RenderingCore::drawTracersAndESP()
 			}
 		}
 
+	}
+	
+	if (draw_entity_esp || draw_entity_tracers) {
+		auto allObjects = env.getAllActiveObjects();
+
+		for (auto &it : allObjects) {
+			ClientActiveObject *cao = it.second;
+			if (cao->isLocalPlayer() || cao->getParent())
+				continue;
+			GenericCAO *obj = dynamic_cast<GenericCAO *>(cao);
+			if (! obj)
+				continue;
+			aabb3f box;
+			if (! obj->getSelectionBox(&box))
+				continue;
+			if (obj->isPlayer())
+				continue;
+			v3f pos = obj->getPosition() - camera_offset;
+			box.MinEdge += pos;
+			box.MaxEdge += pos;
+			
+			auto esp_color = g_settings->get("entity_esp_color");
+			auto tracers_color = g_settings->get("entity_tracers_color");
+			
+			if (draw_esp)
+				if (m_esp_color == "red")
+					driver->draw3DBox(box, video::SColor(0xFF0000));
+				else if (m_esp_color == "lime")
+					driver->draw3DBox(box, video::SColor(0x00FF00));
+				else if (m_esp_color == "purple")
+					driver->draw3DBox(box, video::SColor(0x800080));
+				else if (m_esp_color == "pink")
+					driver->draw3DBox(box, video::SColor(0xFFC0CB));
+				else if (m_esp_color == "green")
+					driver->draw3DBox(box, video::SColor(0x008000));
+				else if (m_esp_color == "blue")
+					driver->draw3DBox(box, video::SColor(0x0000FF));
+				else if (m_esp_color == "yellow")
+					driver->draw3DBox(box, video::SColor(0xFFFF00));
+				else if (m_esp_color == "white")
+					driver->draw3DBox(box, video::SColor(0xFFFFFF));
+				else if (m_esp_color == "black")
+					driver->draw3DBox(box, video::SColor(0x000000));
+				else if (m_esp_color == "brown")
+					driver->draw3DBox(box, video::SColor(0xA52A2A));
+				else if (m_esp_color == "orange")
+					driver->draw3DBox(box, video::SColor(0xFFA500));
+				else
+					driver->draw3DBox(box, video::SColor(0xFFFFFF));
+			if (draw_tracers)
+				if (m_tracers_color == "red")
+					driver->draw3DBox(box, video::SColor(0xFF0000));
+				else if (m_tracers_color == "lime")
+					driver->draw3DBox(box, video::SColor(0x00FF00));
+				else if (m_tracers_color == "purple")
+					driver->draw3DBox(box, video::SColor(0x800080));
+				else if (m_tracers_color == "pink")
+					driver->draw3DBox(box, video::SColor(0xFFC0CB));
+				else if (m_tracers_color == "green")
+					driver->draw3DBox(box, video::SColor(0x008000));
+				else if (m_tracers_color == "blue")
+					driver->draw3DBox(box, video::SColor(0x0000FF));
+				else if (m_tracers_color == "yellow")
+					driver->draw3DBox(box, video::SColor(0xFFFF00));
+				else if (m_tracers_color == "white")
+					driver->draw3DBox(box, video::SColor(0xFFFFFF));
+				else if (m_tracers_color == "black")
+					driver->draw3DBox(box, video::SColor(0x000000));
+				else if (m_tracers_color == "brown")
+					driver->draw3DBox(box, video::SColor(0xA52A2A));
+				else if (m_tracers_color == "orange")
+					driver->draw3DBox(box, video::SColor(0xFFA500));
+		}
 	}
 	
 	driver->setMaterial(oldmaterial);

--- a/src/client/render/core.h
+++ b/src/client/render/core.h
@@ -40,6 +40,8 @@ protected:
 	bool draw_tracers;
 	bool draw_node_esp;
 	bool draw_node_tracers;
+	bool draw_entity_esp;
+	bool draw_entity_tracers;
 
 	IrrlichtDevice *device;
 	video::IVideoDriver *driver;
@@ -75,7 +77,7 @@ public:
 	void initialize();
 	void draw(video::SColor _skycolor, bool _show_hud, bool _show_minimap,
 			bool _draw_wield_tool, bool _draw_crosshair, bool _draw_esp,
-			bool _draw_tracers, bool _draw_node_esp, bool _draw_node_tracers);
+			bool _draw_tracers, bool _draw_node_esp, bool _draw_node_tracers, bool _draw_entity_esp, bool _draw_entity_tracers);
 
 	inline v2u32 getVirtualSize() const { return virtual_size; }
 };

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -604,9 +604,9 @@ void RenderingEngine::_finalize()
 }
 
 void RenderingEngine::_draw_scene(video::SColor skycolor, bool show_hud,
-		bool show_minimap, bool draw_wield_tool, bool draw_crosshair, bool draw_esp, bool draw_tracers, bool draw_node_esp, bool draw_node_tracers)
+		bool show_minimap, bool draw_wield_tool, bool draw_crosshair, bool draw_esp, bool draw_tracers, bool draw_node_esp, bool draw_node_tracers, bool draw_entity_esp, bool draw_entity_tracers)
 {
-	core->draw(skycolor, show_hud, show_minimap, draw_wield_tool, draw_crosshair, draw_esp, draw_tracers, draw_node_esp, draw_node_tracers);
+	core->draw(skycolor, show_hud, show_minimap, draw_wield_tool, draw_crosshair, draw_esp, draw_tracers, draw_node_esp, draw_node_tracers, draw_entity_esp, draw_entity_tracers);
 }
 
 const char *RenderingEngine::getVideoDriverName(irr::video::E_DRIVER_TYPE type)

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -117,10 +117,10 @@ public:
 	}
 
 	inline static void draw_scene(video::SColor skycolor, bool show_hud,
-			bool show_minimap, bool draw_wield_tool, bool draw_crosshair, bool draw_esp, bool draw_tracers, bool draw_node_esp, bool draw_node_tracers)
+			bool show_minimap, bool draw_wield_tool, bool draw_crosshair, bool draw_esp, bool draw_tracers, bool draw_node_esp, bool draw_node_tracers, bool draw_entity_esp, bool draw_entity_tracers)
 	{
 		s_singleton->_draw_scene(skycolor, show_hud, show_minimap,
-				draw_wield_tool, draw_crosshair, draw_esp, draw_tracers, draw_node_esp, draw_node_tracers);
+				draw_wield_tool, draw_crosshair, draw_esp, draw_tracers, draw_node_esp, draw_node_tracers, bool draw_entity_esp, bool draw_entity_tracers);
 	}
 
 	inline static void initialize(Client *client, Hud *hud)

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -120,7 +120,7 @@ public:
 			bool show_minimap, bool draw_wield_tool, bool draw_crosshair, bool draw_esp, bool draw_tracers, bool draw_node_esp, bool draw_node_tracers, bool draw_entity_esp, bool draw_entity_tracers)
 	{
 		s_singleton->_draw_scene(skycolor, show_hud, show_minimap,
-				draw_wield_tool, draw_crosshair, draw_esp, draw_tracers, draw_node_esp, draw_node_tracers, bool draw_entity_esp, bool draw_entity_tracers);
+				draw_wield_tool, draw_crosshair, draw_esp, draw_tracers, draw_node_esp, draw_node_tracers, draw_entity_esp, draw_entity_tracers);
 	}
 
 	inline static void initialize(Client *client, Hud *hud)

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -148,7 +148,7 @@ private:
 			bool clouds = true);
 
 	void _draw_scene(video::SColor skycolor, bool show_hud, bool show_minimap,
-			bool draw_wield_tool, bool draw_crosshair, bool draw_esp, bool draw_tracers, bool draw_node_esp, bool draw_node_tracers);
+			bool draw_wield_tool, bool draw_crosshair, bool draw_esp, bool draw_tracers, bool draw_node_esp, bool draw_node_tracers, bool draw_entity_esp, bool draw_entity_tracers);
 
 	void _initialize(Client *client, Hud *hud);
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -153,6 +153,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("entity_tracers_color", "lime");
 	setitngs->setDefault("custom_fall_damage", "false");
 	settings->setDefault("fall_damage", "1");
+	setttigs->setDefault("autoattack", "false");
 
 	// Keymap
 	settings->setDefault("remote_port", "30000");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -151,6 +151,8 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("esp_color", "white");
 	settings->setDefault("entity_esp_color", "red");
 	settings->setDefault("entity_tracers_color", "lime");
+	setitngs->setDefault("custom_fall_damage", "false");
+	settings->setDefault("fall_damage", "1");
 
 	// Keymap
 	settings->setDefault("remote_port", "30000");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -147,6 +147,10 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("antislip", "false");
 	settings->setDefault("enable_entity_esp", "false");
 	settings->setDefault("enable_entity_tracers", "false");
+	settings->setDefault("tracers_color", "white");
+	settings->setDefault("esp_color", "white");
+	settings->setDefault("entity_esp_color", "red");
+	settings->setDefault("entity_tracers_color", "lime");
 
 	// Keymap
 	settings->setDefault("remote_port", "30000");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -144,7 +144,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("override_gravity_factor", "0.9");
 	settings->setDefault("jetpack", "false");
 	settings->setDefault("autohit", "false");
-	settings->setDefault("antislip", "false");
+	settings->setDefault("noslip", "false");
 	settings->setDefault("enable_entity_esp", "false");
 	settings->setDefault("enable_entity_tracers", "false");
 	settings->setDefault("tracers_color", "white");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -145,6 +145,8 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("jetpack", "false");
 	settings->setDefault("autohit", "false");
 	settings->setDefault("antislip", "false");
+	settings->setDefault("enable_entity_esp", "false");
+	settings->setDefault("enable_entity_tracers", "false");
 
 	// Keymap
 	settings->setDefault("remote_port", "30000");


### PR DESCRIPTION
New:
1) EntitESP _Highlights entityts_
2) EntityTracers _Draw tracers towards all entitys in range_
3) ESP, Tracers, EntityESP and EntityTracers have been made configurable. Well at least the color.
4) Availible colors: _red, lime, purple, pink, green, blue, yellow, white, black, brown and orange_
5) ESP and Tracers now _only highlight players_
6) CustomFallDamage _Set your fall damage with: .set -n fall_damage <value>. Warning: value has to be a number. And only works when CustomFallDamage is enabled!_

Deprecated:
1) OnlyTracePlayers