### PR TITLE
Add mapseed to get_server_info table

### DIFF
--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -1639,7 +1639,8 @@ It can be created via `Raycast(pos1, pos2, objects, liquids)` or
 	address = "minetest.example.org", -- The domain name/IP address of a remote server or "" for a local server.
 	ip = "203.0.113.156",             -- The IP address of the server.
 	port = 30000,                     -- The port the client is connected to.
-	protocol_version = 30             -- Will not be accurate at start up as the client might not be connected to the server yet, in that case it will be 0.
+	protocol_version = 30,            -- Will not be accurate at start up as the client might not be connected to the server yet, in that case it will be 0.
+	seed = 123                        -- Map Seed of the current map
 }
 ```
 

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -332,6 +332,8 @@ int ModApiClient::l_get_server_info(lua_State *L)
 	lua_setfield(L, -2, "port");
 	lua_pushinteger(L, client->getProtoVersion());
 	lua_setfield(L, -2, "protocol_version");
+	lua_pushinteger(L, client->getMapSeed());
+	lua_setfield(L, -2, "seed");
 	return 1;
 }
 


### PR DESCRIPTION
This adds the readily available information of the current mapseed to the table returned by minetest.get_server_info()

### Testing
Install https://github.com/corarona/mcl_find_strongholds and run .find_strongholds (if run without argument it should output a list of mcl* stronghold positions for the current mapseed)