### PR TITLE
Add list setting -> chatcmd def for external access

### DIFF
--- a/builtin/common/chatcommands.lua
+++ b/builtin/common/chatcommands.lua
@@ -74,6 +74,7 @@ if INIT == "client" then
 		local def = {}
 		def.description = desc
 		def.params = "del <item> | add <item> | list"
+		def._list_setting = setting
 		function def.func(param)
 			local list = (minetest.settings:get(setting) or ""):split(",")
 			if param == "list" then

--- a/builtin/common/chatcommands.lua
+++ b/builtin/common/chatcommands.lua
@@ -74,7 +74,7 @@ if INIT == "client" then
 		local def = {}
 		def.description = desc
 		def.params = "del <item> | add <item> | list"
-		def._list_setting = setting
+		def.list_setting = setting
 		function def.func(param)
 			local list = (minetest.settings:get(setting) or ""):split(",")
 			if param == "list" then

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -712,7 +712,7 @@ Call these functions only at load time!
     * `add` adds something to the list
     * `del` del removes something from the list
     * `list` lists all items on the list
-    * The field `_list_setting` will be set in the chatcommand definition to be able to recover it the
+    * The field `list_setting` will be set in the chatcommand definition to be able to recover it the
       value of the 3rd parameter (settings) from minetest.registered_chatcommands later.
 * `minetest.register_on_chatcommand(function(command, params))`
     * Called always when a chatcommand is triggered, before `minetest.registered_chatcommands`
@@ -1634,7 +1634,7 @@ It can be created via `Raycast(pos1, pos2, objects, liquids)` or
         description = "Remove privilege from player", -- Full description
         func = function(param),        -- Called when command is run.
                                        -- Returns boolean success and text output.
-        _list_setting,                 -- this field will be automatically set by the minetest.register_list_command reflecting the 3rd "setting" parameter
+        list_setting,                  -- this field will be automatically set by the minetest.register_list_command reflecting the 3rd "setting" parameter
     }
 ### Server info
 ```lua

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -1634,7 +1634,7 @@ It can be created via `Raycast(pos1, pos2, objects, liquids)` or
         description = "Remove privilege from player", -- Full description
         func = function(param),        -- Called when command is run.
                                        -- Returns boolean success and text output.
-        _list_setting,                 -- this field will be automatically set the minetest.register_list_command reflecting the 3rd "setting" parameter
+        _list_setting,                 -- this field will be automatically set by the minetest.register_list_command reflecting the 3rd "setting" parameter
     }
 ### Server info
 ```lua

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -712,6 +712,8 @@ Call these functions only at load time!
     * `add` adds something to the list
     * `del` del removes something from the list
     * `list` lists all items on the list
+    * The field `_list_setting` will be set in the chatcommand definition to be able to recover it the
+      value of the 3rd parameter (settings) from minetest.registered_chatcommands later.
 * `minetest.register_on_chatcommand(function(command, params))`
     * Called always when a chatcommand is triggered, before `minetest.registered_chatcommands`
       is checked to see if that the command exists, but after the input is parsed.
@@ -1632,6 +1634,7 @@ It can be created via `Raycast(pos1, pos2, objects, liquids)` or
         description = "Remove privilege from player", -- Full description
         func = function(param),        -- Called when command is run.
                                        -- Returns boolean success and text output.
+        _list_setting,                 -- this field will be automatically set the minetest.register_list_command reflecting the 3rd "setting" parameter
     }
 ### Server info
 ```lua


### PR DESCRIPTION
This adds the setting name to the listcmd chatcommand to allow external mods to access the mapping between command name and setting.

e.g. https://github.com/corarona/nlist