### PR TITLE
Add register_on_receive_particlespawner csm callback

### DIFF
--- a/builtin/client/register.lua
+++ b/builtin/client/register.lua
@@ -104,6 +104,7 @@ core.registered_on_inventory_open, core.register_on_inventory_open = make_regist
 core.registered_on_recieve_physics_override, core.register_on_recieve_physics_override = make_registration()
 core.registered_on_play_sound, core.register_on_play_sound = make_registration()
 core.registered_on_spawn_particle, core.register_on_spawn_particle = make_registration()
+core.registered_on_receive_particlespawner, core.register_on_receive_particlespawner = make_registration()
 core.registered_on_object_properties_change, core.register_on_object_properties_change = make_registration()
 core.registered_on_object_hp_change, core.register_on_object_hp_change = make_registration()
 core.registered_on_object_add, core.register_on_object_add = make_registration()

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -774,6 +774,10 @@ Call these functions only at load time!
     * Called when recieving a spawn particle command from server
     * Newest functions are called first
     * If any function returns true, the particle does not spawn
+* `minetest.register_on_receive_particlespawner(function(particleSpawner parameters))`
+    * Called when recieving a particlespawner from the server
+    * Newest functions are called first
+    * If any function returns true, the particlespawner will not be created on the client
 * `minetest.register_on_object_add(function(obj))`
 	* Called every time an object is added
 * `minetest.register_on_object_properties_change(function(obj))`

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -770,7 +770,7 @@ Call these functions only at load time!
     * Called when recieving a play sound command from server
     * Newest functions are called first
     * If any function returns true, the sound does not play
-* `minetest.register_on_spawn_partice(function(particle definition))`
+* `minetest.register_on_spawn_particle(function(particle definition))`
     * Called when recieving a spawn particle command from server
     * Newest functions are called first
     * If any function returns true, the particle does not spawn

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1056,7 +1056,7 @@ void Client::handleCommand_AddParticleSpawner(NetworkPacket* pkt)
 	event->add_particlespawner.p           = new ParticleSpawnerParameters(p);
 	event->add_particlespawner.attached_id = attached_id;
 	event->add_particlespawner.id          = server_id;
-
+	if (m_mods_loaded && m_script->on_receive_particlespawner(*event->add_particlespawner.p)) return;
 	m_client_event_queue.push(event);
 }
 

--- a/src/script/cpp_api/s_client.cpp
+++ b/src/script/cpp_api/s_client.cpp
@@ -346,6 +346,48 @@ bool ScriptApiClient::on_spawn_particle(struct ParticleParameters param)
 	return readParam<bool>(L, -1);
 }
 
+bool ScriptApiClient::on_receive_particlespawner(struct ParticleSpawnerParameters param)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "registered_on_receive_particlespawner");
+
+	// Push data
+	lua_newtable(L);
+	setstringfield(L, -1, "texture", param.texture);
+	lua_pushinteger(L, param.amount);
+	lua_setfield(L, -2, "amount");
+	push_v3f(L, param.minpos);
+	lua_setfield(L, -2, "minpos");
+	push_v3f(L, param.maxpos);
+	lua_setfield(L, -2, "maxpos");
+	push_v3f(L, param.minvel);
+	lua_setfield(L, -2, "minvel");
+	push_v3f(L, param.maxvel);
+	lua_setfield(L, -2, "maxvel");
+	push_v3f(L, param.minacc);
+	lua_setfield(L, -2, "minacc");
+	push_v3f(L, param.maxacc);
+	lua_setfield(L, -2, "maxacc");
+	lua_pushnumber(L, param.time);
+	lua_setfield(L, -2, "time");
+	lua_pushnumber(L, param.minexptime);
+	lua_setfield(L, -2, "minexptime");
+	lua_pushnumber(L, param.maxexptime);
+	lua_setfield(L, -2, "maxexptime");
+	lua_pushnumber(L, param.minsize);
+	lua_setfield(L, -2, "minsize");
+	lua_pushnumber(L, param.maxsize);
+	lua_setfield(L, -2, "maxsize");
+	lua_pushinteger(L, param.collisiondetection);
+	lua_setfield(L, -2, "collisiondetection");
+
+	// Call functions
+	runCallbacks(1, RUN_CALLBACKS_MODE_OR);
+	return readParam<bool>(L, -1);
+}
+
 void ScriptApiClient::on_object_properties_change(s16 id)
 {
 	SCRIPTAPI_PRECHECKHEADER

--- a/src/script/cpp_api/s_client.h
+++ b/src/script/cpp_api/s_client.h
@@ -63,6 +63,7 @@ public:
 			bool new_move);
 	bool on_play_sound(SimpleSoundSpec spec);
 	bool on_spawn_particle(struct ParticleParameters param);
+	bool on_receive_particlespawner(struct ParticleSpawnerParameters param);
 	void on_object_properties_change(s16 id);
 	void on_object_hp_change(s16 id);
 	bool on_object_add(s16 id);


### PR DESCRIPTION
This adds minetest.register_on_receive_particlespawner(function(particle_spawner_parameters)) as a lua callback.

Use cases are for example an updated version of the no_weather CSM for mcl* or potentially coord exploits. 

## How to test
Add a csm with

```lua
minetest.register_on_receive_particlespawner(function(p)
    minetest.display_chat_message(dump(p))
end)
```

Start a game with mineclone, run /findbiome mushroomisland (the mycelium adds particlespawners).

See the spawner parameters coming in in chat.