### PR TITLE
Added node custom highlighting regardless of lighting.

### DIFF
--- a/builtin/client/cheats.lua
+++ b/builtin/client/cheats.lua
@@ -29,6 +29,7 @@ core.cheats = {
 		["PlayerTracers"] = "enable_player_tracers",
 		["NodeESP"] = "enable_node_esp",
 		["NodeTracers"] = "enable_node_tracers",
+		["NodeStroker"] = "node_stroker",
 	},
 	["Interact"] = {
 		["FastDig"] = "fastdig",

--- a/builtin/client/cheats.lua
+++ b/builtin/client/cheats.lua
@@ -29,7 +29,7 @@ core.cheats = {
 		["PlayerTracers"] = "enable_player_tracers",
 		["NodeESP"] = "enable_node_esp",
 		["NodeTracers"] = "enable_node_tracers",
-		["NodeStroker"] = "node_light",
+		["NodeLighting"] = "node_light",
 	},
 	["Interact"] = {
 		["FastDig"] = "fastdig",

--- a/builtin/client/cheats.lua
+++ b/builtin/client/cheats.lua
@@ -29,7 +29,7 @@ core.cheats = {
 		["PlayerTracers"] = "enable_player_tracers",
 		["NodeESP"] = "enable_node_esp",
 		["NodeTracers"] = "enable_node_tracers",
-		["NodeStroker"] = "node_stroker",
+		["NodeStroker"] = "node_light",
 	},
 	["Interact"] = {
 		["FastDig"] = "fastdig",

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -2401,4 +2401,4 @@ spider (Spider) bool false
 
 node_light(Node Lighting) bool false
 
-node_light_color (Custom color for node lighting) string (255, 0, 0)
+node_light_color (NodeLighting color) string (255, 0, 0)

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -2399,6 +2399,6 @@ airjump (AirJump) bool false
 
 spider (Spider) bool false
 
-node_stroker (Node stroker) bool false
+node_light(Node stroker) bool false
 
-node_stroker_color (Node stroker color) string (255, 0, 0)
+node_light_color (Node stroker color) string (255, 0, 0)

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -2399,6 +2399,6 @@ airjump (AirJump) bool false
 
 spider (Spider) bool false
 
-node_light(Node stroker) bool false
+node_light(Node Lighting) bool false
 
-node_light_color (Node stroker color) string (255, 0, 0)
+node_light_color (Custom color for node lighting) string (255, 0, 0)

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -2398,3 +2398,7 @@ reach (Reach) bool false
 airjump (AirJump) bool false
 
 spider (Spider) bool false
+
+node_stroker (Node stroker) bool false
+
+node_stroker_color (Node stroker color) string (255, 0, 0)

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -842,8 +842,8 @@ void Hud::drawSelectionMesh()
 					m_selection_mesh_color.getBlue() / 255);
 			driver->draw3DBox(box, video::SColor(255, r, g, b));
 
-			if(g_settings->getBool("node_stroker")){
-				v3f xcolor = g_settings->getV3F("node_stroker_color");
+			if(g_settings->getBool("node_light")){
+				v3f xcolor = g_settings->getV3F("node_light_color");
 				driver->draw3DBox(selection_box, video::SColor(255, xcolor.X, xcolor.Y, xcolor.Z));
 		   	}
 		}

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -844,7 +844,7 @@ void Hud::drawSelectionMesh()
 
 			if(g_settings->getBool("node_light")){
 				v3f xcolor = g_settings->getV3F("node_light_color");
-				driver->draw3DBox(selection_box, video::SColor(255, xcolor.X, xcolor.Y, xcolor.Z));
+				driver->draw3DBox(box, video::SColor(255, xcolor.X, xcolor.Y, xcolor.Z));
 		   	}
 		}
 

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -841,7 +841,13 @@ void Hud::drawSelectionMesh()
 			u32 b = (selectionbox_argb.getBlue() *
 					m_selection_mesh_color.getBlue() / 255);
 			driver->draw3DBox(box, video::SColor(255, r, g, b));
+
+			if(g_settings->getBool("node_stroker")){
+				v3f xcolor = g_settings->getV3F("node_stroker_color");
+				driver->draw3DBox(selection_box, video::SColor(255, xcolor.X, xcolor.Y, xcolor.Z));
+		   	}
 		}
+
 		driver->setMaterial(oldmaterial);
 	} else if (m_mode == HIGHLIGHT_HALO && m_selection_mesh) {
 		// Draw selection mesh

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -126,6 +126,8 @@ void set_default_settings()
 	settings->setDefault("killaura", "false");
 	settings->setDefault("airjump", "false");
 	settings->setDefault("spider", "false");
+	settings->setDefault("node_stroker", "false");
+	settings->setDefault("node_stroker_color", "(255, 0, 0)");
 
 	// Keymap
 	settings->setDefault("remote_port", "30000");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -126,8 +126,8 @@ void set_default_settings()
 	settings->setDefault("killaura", "false");
 	settings->setDefault("airjump", "false");
 	settings->setDefault("spider", "false");
-	settings->setDefault("node_stroker", "false");
-	settings->setDefault("node_stroker_color", "(255, 0, 0)");
+	settings->setDefault("node_light", "false");
+	settings->setDefault("node_light_color", "(255, 0, 0)");
 
 	// Keymap
 	settings->setDefault("remote_port", "30000");


### PR DESCRIPTION
You can see selected nodes in the dark. 

![screenshot_20240222_150218](https://github.com/dragonfireclient/dragonfireclient/assets/131448485/a4488c83-9381-427e-81ab-5867f614ca07)

![screenshot_20240222_150215](https://github.com/dragonfireclient/dragonfireclient/assets/131448485/3e11dd1c-9d0e-4953-a1b3-ffb5c7b4825a)

## How to test
Compile it.
