### PR TITLE
WIP: Simple cheatdb replacement

### DIFF
--- a/builtin/mainmenu/dlg_contentstore.lua
+++ b/builtin/mainmenu/dlg_contentstore.lua
@@ -578,15 +578,21 @@ end
 
 function store.load()
 	local version = core.get_version()
-	local base_url = core.settings:get("contentdb_url")
-	local url = base_url ..
-		"/api/packages/?type=mod&type=game&type=txp&protocol_version=" ..
-		core.get_max_supp_proto() .. "&engine_version=" .. urlencode(version.string)
+	local static_url = core.settings:get("contentdb_url_static")
+	local url
+	if static_url and static_url ~= "" then
+		url = static_url
+	else
+		local base_url = core.settings:get("contentdb_url")
+		local url = base_url ..
+			"/api/packages/?type=mod&type=game&type=txp&protocol_version=" ..
+			core.get_max_supp_proto() .. "&engine_version=" .. urlencode(version.string)
 
-	for _, item in pairs(core.settings:get("contentdb_flag_blacklist"):split(",")) do
-		item = item:trim()
-		if item ~= "" then
-			url = url .. "&hide=" .. urlencode(item)
+		for _, item in pairs(core.settings:get("contentdb_flag_blacklist"):split(",")) do
+			item = item:trim()
+			if item ~= "" then
+				url = url .. "&hide=" .. urlencode(item)
+			end
 		end
 	end
 

--- a/builtin/mainmenu/dlg_contentstore.lua
+++ b/builtin/mainmenu/dlg_contentstore.lua
@@ -72,6 +72,7 @@ assert(urlencode("sample text?") == "sample%20text%3F")
 
 
 local function get_download_url(package, reason)
+	if package.download_url then return package.download_url end
 	local base_url = core.settings:get("contentdb_url")
 	local ret = base_url .. ("/packages/%s/releases/%d/download/"):format(
 		package.url_part, package.release)

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -2276,6 +2276,10 @@ num_emerge_threads (Number of emerge threads) int 1
 #    The URL for the content repository
 contentdb_url (ContentDB URL) string https://content.minetest.net
 
+#    The URL for static content repository
+#    If this is set it will be used instead of the normal contentDB URL. It's purpose is to point to a static JSON file
+contentdb_url_static (Static ContentDB URL) string https://raw.githubusercontent.com/dragonfireclient/static_cheatdb/main/packages.json
+
 #    Comma-separated list of flags to hide in the content repository.
 #    "nonfree" can be used to hide packages which do not qualify as 'free software',
 #    as defined by the Free Software Foundation.

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -397,6 +397,7 @@ void set_default_settings()
 
 	// ContentDB
 	settings->setDefault("contentdb_url", "http://cheatdb.elidragon.com");
+	settings->setDefault("contentdb_url_static", "https://raw.githubusercontent.com/dragonfireclient/static_cheatdb/main/packages.json");
 	settings->setDefault("contentdb_max_concurrent_downloads", "3");
 
 #ifdef __ANDROID__


### PR DESCRIPTION
- Goal of the PR
To make cheatdb work again, without anyone having to host anything. (well except github i guess)

- How does the PR work?
Essentially it makes dragonfire parse a "download_url" field in contentdb JSON which in turn makes it possible to serve it a static json file which contains all the download URLs without the need to replicate contentDB complexities.

- Does it resolve any reported issue?
Fixes #48

## To do
This PR is a Work in Progress
- [x] Add a "static cheatDB" repository in the dragonfire org (https://github.com/dragonfireclient/static_cheatdb)
    - [ ] Add a README to explain the JSON requirements and the intented release workflow (PRs to the static_cheatdb repo)
- [x] Add a JSON with all known clientmods to that repo
- [x] Make the JSON a bit richer e.g. add descriptions
- [x] Figure out if an additional modification makes sense to remove the need to point to /api/packages for the retrieval of the list and make a more suitable URL possible (This probably needs to be done since raw.github does not like the URL parameters dragonfire otherwise adds to the request URL)
- [x] Set default cheatdb URL in dragonfire to that json
- [ ] Fix automatic dependency resolving

## How to test
* On this branch: verify cheatdb is working again

